### PR TITLE
Addons analyses port

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ Metrics/LineLength:
 Metrics/ClassLength:
   Max: 200
 
+Metrics/ModuleLength:
+  Max: 200
+
 Metrics/ParameterLists:
   Max: 15
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,9 @@ Metrics/LineLength:
 Metrics/ClassLength:
   Max: 200
 
+Metrics/ParameterLists:
+  Max: 15
+
 Style/Tab:
   Enabled: false
 

--- a/bin/dgit
+++ b/bin/dgit
@@ -21,198 +21,201 @@
 require 'gli'
 require_relative '../lib/dgit'
 
-include GLI::App
+module Diggit
+	include GLI::App
 
-program_desc 'A git repository analysis tool.'
+	extend self
+	program_desc 'A git repository analysis tool.'
 
-switch [:v, :verbose], default_value: false, negatable: false, desc: "Indicates if the debug information are visible."
-flag [:f, :folder], default_value: ".", desc: "Path to the diggit folder. Default: current folder."
+	switch [:v, :verbose], default_value: false, negatable: false, desc: "Indicates if the debug information are visible."
+	flag [:f, :folder], default_value: ".", desc: "Path to the diggit folder. Default: current folder."
 
-version Diggit::VERSION
+	version Diggit::VERSION
 
-subcommand_option_handling :normal
-arguments :strict
+	subcommand_option_handling :normal
+	arguments :strict
 
-desc 'Init a diggit folder.'
-skips_pre
-command :init do |c|
-	c.action do |globals, _options, _args|
-		Diggit::Dig.init_dir globals[:f]
-		Log.ok "Diggit folder initialized."
-	end
-end
-
-desc 'Display the status of the diggit folder.'
-command :status do |c|
-	c.action do |_global_options, _options, _args|
-		Log.info "Config"
-		Log.info "======"
-		Log.info "- Analyses: #{Diggit::Dig.it.config.get_analyses.join(', ')}"
-		Log.info "- Joins: #{Diggit::Dig.it.config.get_joins.join(', ')}"
-		Log.info ""
-		Log.info "Journal"
-		Log.info "======="
-		Log.info "- New sources:"
-		Log.indent do
-			Log.ok "* Ok: #{Diggit::Dig.it.journal.sources_by_state(:new).size}"
-			Log.error "* Error: #{Diggit::Dig.it.journal.sources_by_state(:new, true).size}"
-		end
-		Log.info "- Cloned sources:"
-		Log.indent do
-			Log.ok "* Ok: #{Diggit::Dig.it.journal.sources_by_state(:cloned).size}"
-			Log.error "* Error: #{Diggit::Dig.it.journal.sources_by_state(:cloned, true).size}"
+	desc 'Init a diggit folder.'
+	skips_pre
+	command :init do |c|
+		c.action do |globals, _options, _args|
+			Diggit::Dig.init_dir globals[:f]
+			Log.ok "Diggit folder initialized."
 		end
 	end
-end
 
-desc 'Manage the sources of the diggit folder.'
-command :sources do |c|
-	c.desc 'List the sources.'
-	c.command :list do |list|
-		list.action do |_global_options, _options, _args|
-			sources = Diggit::Dig.it.journal.sources
-			sources.each_index do |idx|
-				msg = "#{idx}	#{sources[idx].url} (#{sources[idx].state})"
-				sources[idx].error? ? Log.error(msg) : Log.ok(msg)
+	desc 'Display the status of the diggit folder.'
+	command :status do |c|
+		c.action do |_global_options, _options, _args|
+			Log.info "Config"
+			Log.info "======"
+			Log.info "- Analyses: #{Diggit::Dig.it.config.get_analyses.join(', ')}"
+			Log.info "- Joins: #{Diggit::Dig.it.config.get_joins.join(', ')}"
+			Log.info ""
+			Log.info "Journal"
+			Log.info "======="
+			Log.info "- New sources:"
+			Log.indent do
+				Log.ok "* Ok: #{Diggit::Dig.it.journal.sources_by_state(:new).size}"
+				Log.error "* Error: #{Diggit::Dig.it.journal.sources_by_state(:new, true).size}"
+			end
+			Log.info "- Cloned sources:"
+			Log.indent do
+				Log.ok "* Ok: #{Diggit::Dig.it.journal.sources_by_state(:cloned).size}"
+				Log.error "* Error: #{Diggit::Dig.it.journal.sources_by_state(:cloned, true).size}"
 			end
 		end
 	end
-	c.desc 'Add a source.'
-	c.arg_name 'url'
-	c.command :add do |add|
-		add.action do |_global_options, _options, args|
-			Diggit::Dig.it.journal.add_source args[0]
-		end
-	end
-	c.desc 'Import sources from a file.'
-	c.arg_name 'file'
-	c.command :import do |import|
-		import.action do |_global_options, _options, args|
-			File.open(args[0]).each { |line| Diggit::Dig.it.journal.add_source(line) }
-		end
-	end
-	c.desc 'Display all sources in error.'
-	c.command :errors do |errors|
-		errors.action do |_global_options, _options, _args|
-			sources = Diggit::Dig.it.journal.sources
-			sources.each_index do |idx|
-				msg = "#{idx}	#{sources[idx].url} (#{sources[idx].state})"
-				Log.error msg if sources[idx].error?
-			end
-		end
-	end
-	c.desc 'Display information on a source'
-	c.arg_name 'id'
-	c.command :info do |info|
-		info.action do |_global_options, _options, args|
-			src = Diggit::Dig.it.journal.sources_by_ids(args.to_i)
-			url = "URL: #{src.url}"
-			src.error? ? Log.error(url) : Log.info(url)
-			Log.info "State: #{src.state}"
-			Log.info "Performed analyses: #{src.performed_analyses.join(', ')}" unless src.performed_analyses.empty?
-			Log.error "Ongoing analyses: #{src.ongoing_analyses.join(', ')}" unless src.ongoing_analyses.emtpy?
-			if src.error?
-				error = src.error
-				Log.indent do
-					Log.error error[:message]
-					Log.info error[:backtrace].join("\n")
+
+	desc 'Manage the sources of the diggit folder.'
+	command :sources do |c|
+		c.desc 'List the sources.'
+		c.command :list do |list|
+			list.action do |_global_options, _options, _args|
+				sources = Diggit::Dig.it.journal.sources
+				sources.each_index do |idx|
+					msg = "#{idx}	#{sources[idx].url} (#{sources[idx].state})"
+					sources[idx].error? ? Log.error(msg) : Log.ok(msg)
 				end
 			end
 		end
+		c.desc 'Add a source.'
+		c.arg_name 'url'
+		c.command :add do |add|
+			add.action do |_global_options, _options, args|
+				Diggit::Dig.it.journal.add_source args[0]
+			end
+		end
+		c.desc 'Import sources from a file.'
+		c.arg_name 'file'
+		c.command :import do |import|
+			import.action do |_global_options, _options, args|
+				File.open(args[0]).each { |line| Diggit::Dig.it.journal.add_source(line) }
+			end
+		end
+		c.desc 'Display all sources in error.'
+		c.command :errors do |errors|
+			errors.action do |_global_options, _options, _args|
+				sources = Diggit::Dig.it.journal.sources
+				sources.each_index do |idx|
+					msg = "#{idx}	#{sources[idx].url} (#{sources[idx].state})"
+					Log.error msg if sources[idx].error?
+				end
+			end
+		end
+		c.desc 'Display information on a source'
+		c.arg_name 'id'
+		c.command :info do |info|
+			info.action do |_global_options, _options, args|
+				src = Diggit::Dig.it.journal.sources_by_ids(args.to_i)
+				url = "URL: #{src.url}"
+				src.error? ? Log.error(url) : Log.info(url)
+				Log.info "State: #{src.state}"
+				Log.info "Performed analyses: #{src.performed_analyses.join(', ')}" unless src.performed_analyses.empty?
+				Log.error "Ongoing analyses: #{src.ongoing_analyses.join(', ')}" unless src.ongoing_analyses.emtpy?
+				if src.error?
+					error = src.error
+					Log.indent do
+						Log.error error[:message]
+						Log.info error[:backtrace].join("\n")
+					end
+				end
+			end
+		end
+		c.default_command :list
 	end
-	c.default_command :list
-end
 
-desc 'Manage the joins of the diggit folder.'
-command :joins do |c|
-	c.desc 'List the joins'
-	c.command :list do |list|
-		list.action do |_global_options, _options, _args|
-			Diggit::Dig.it.config.get_joins.each { |a| Log.info a.name }
+	desc 'Manage the joins of the diggit folder.'
+	command :joins do |c|
+		c.desc 'List the joins'
+		c.command :list do |list|
+			list.action do |_global_options, _options, _args|
+				Diggit::Dig.it.config.get_joins.each { |a| Log.info a.name }
+			end
 		end
-	end
-	c.desc 'Add add join.'
-	c.arg_name 'name'
-	c.command :add do |add|
-		add.action do |_global_options, _options, args|
-			Diggit::Dig.it.config.add_join args[0]
+		c.desc 'Add add join.'
+		c.arg_name 'name'
+		c.command :add do |add|
+			add.action do |_global_options, _options, args|
+				Diggit::Dig.it.config.add_join args[0]
+			end
 		end
-	end
-	c.desc 'Perform joins.'
-	c.command :perform do |perform|
-		perform.flag [:s, :sources], desc: "list of sources", type: Array, default_value: []
-		perform.flag [:a, :analyses], desc: "list of analyses", type: Array, default_value: []
-		perform.flag [:m, :mode], desc: "running mode",
-				must_match: { "run" => :run, "clean" => :clean, "rerun" => :rerun }, default_value: :run
-		perform.action do |_global_options, options, _args|
-			Diggit::Dig.it.join(options[:s], options[:a], options[:m])
+		c.desc 'Perform joins.'
+		c.command :perform do |perform|
+			perform.flag [:s, :sources], desc: "list of sources", type: Array, default_value: []
+			perform.flag [:a, :analyses], desc: "list of analyses", type: Array, default_value: []
+			perform.flag [:m, :mode], desc: "running mode",
+					must_match: { "run" => :run, "clean" => :clean, "rerun" => :rerun }, default_value: :run
+			perform.action do |_global_options, options, _args|
+				Diggit::Dig.it.join(options[:s], options[:a], options[:m])
+			end
 		end
+		c.default_command :list
 	end
-	c.default_command :list
-end
 
-desc 'Manage the analyses of the diggit folder.'
-command :analyses do |c|
-	c.desc 'List the analyses'
-	c.command :list do |list|
-		list.action do |_global_options, _options, _args|
-			Diggit::Dig.it.config.get_analyses.each { |a| Log.info a.name }
+	desc 'Manage the analyses of the diggit folder.'
+	command :analyses do |c|
+		c.desc 'List the analyses'
+		c.command :list do |list|
+			list.action do |_global_options, _options, _args|
+				Diggit::Dig.it.config.get_analyses.each { |a| Log.info a.name }
+			end
 		end
-	end
-	c.desc 'Add an analysis.'
-	c.arg_name 'name'
-	c.command :add do |add|
-		add.action do |_global_options, _options, args|
-			Diggit::Dig.it.config.add_analysis args[0]
+		c.desc 'Add an analysis.'
+		c.arg_name 'name'
+		c.command :add do |add|
+			add.action do |_global_options, _options, args|
+				Diggit::Dig.it.config.add_analysis args[0]
+			end
 		end
-	end
-	c.desc 'Delete an analysis.'
-	c.arg_name 'name'
-	c.command :del do |add|
-		add.action do |_global_options, _options, args|
-			Diggit::Dig.it.config.del_analysis args[0]
+		c.desc 'Delete an analysis.'
+		c.arg_name 'name'
+		c.command :del do |add|
+			add.action do |_global_options, _options, args|
+				Diggit::Dig.it.config.del_analysis args[0]
+			end
 		end
-	end
-	c.desc 'Perform analyses.'
-	c.command :perform do |perform|
-		perform.flag [:s, :sources], desc: "list of sources", type: Array, default_value: []
-		perform.flag [:a, :analyses], desc: "list of analyses", type: Array, default_value: []
-		perform.flag [:m, :mode], desc: "running mode",
-				must_match: { "run" => :run, "clean" => :clean, "rerun" => :rerun }, default_value: :run
-		perform.action do |_global_options, options, _args|
-			Diggit::Dig.it.analyze(options[:s], options[:a], options[:m])
+		c.desc 'Perform analyses.'
+		c.command :perform do |perform|
+			perform.flag [:s, :sources], desc: "list of sources", type: Array, default_value: []
+			perform.flag [:a, :analyses], desc: "list of analyses", type: Array, default_value: []
+			perform.flag [:m, :mode], desc: "running mode",
+					must_match: { "run" => :run, "clean" => :clean, "rerun" => :rerun }, default_value: :run
+			perform.action do |_global_options, options, _args|
+				Diggit::Dig.it.analyze(options[:s], options[:a], options[:m])
+			end
 		end
+		c.default_command :list
 	end
-	c.default_command :list
-end
 
-desc 'Manage clone actions.'
-command :clone do |c|
-	c.desc 'Perform the clones.'
-	c.command :perform do |perform|
-		perform.flag [:s, :sources], desc: "list of sources", type: Array, default_value: []
-		perform.action do |_global_options, options, _args|
-			Diggit::Dig.it.clone(*options[:s])
+	desc 'Manage clone actions.'
+	command :clone do |c|
+		c.desc 'Perform the clones.'
+		c.command :perform do |perform|
+			perform.flag [:s, :sources], desc: "list of sources", type: Array, default_value: []
+			perform.action do |_global_options, options, _args|
+				Diggit::Dig.it.clone(*options[:s])
+			end
 		end
+		c.default_command :perform
 	end
-	c.default_command :perform
-end
 
-pre do |globals, _command, _options, _args|
-	Diggit::Dig.init globals[:f]
-	Log.level = :fine if globals[:v]
-	true
-end
+	pre do |globals, _command, _options, _args|
+		Diggit::Dig.init globals[:f]
+		Log.level = :fine if globals[:v]
+		true
+	end
 
-post do |_global, _command, _options, _args|
-		# Post logic here, skips_post to skip commands
-end
+	post do |_global, _command, _options, _args|
+			# Post logic here, skips_post to skip commands
+	end
 
-on_error do |exception|
-	Log.error "Error running diggit."
-	Log.error exception.message
-	Log.info exception.backtrace.join("\n")
-	false
-end
+	on_error do |exception|
+		Log.error "Error running diggit."
+		Log.error exception.message
+		Log.info exception.backtrace.join("\n")
+		false
+	end
 
-exit run(ARGV)
+	exit run(ARGV)
+end

--- a/lib/dgit.rb
+++ b/lib/dgit.rb
@@ -17,7 +17,7 @@
 #
 # Copyright 2015 Jean-Rémy Falleri <jr.falleri@gmail.com>
 
-require_relative "dgit/core"
-require_relative "dgit/plugins"
-require_relative "dgit/version"
-require_relative "dgit/log"
+require "dgit/core"
+require "dgit/plugins"
+require "dgit/version"
+require "dgit/log"

--- a/lib/dgit/core.rb
+++ b/lib/dgit/core.rb
@@ -231,11 +231,11 @@ module Diggit
 		end
 
 		def to_hash
-			{ analyses: @analyses.map(&:name), joins: @joins.map(&:name) }
+			{ analyses: @analyses.map(&:simple_name), joins: @joins.map(&:simple_name) }
 		end
 
 		def add_analysis(name)
-			load_analysis(name) unless @analyses.map(&:name).include?(name)
+			load_analysis(name) unless @analyses.map(&:simple_name).include?(name)
 			Dig.it.save_config
 		end
 
@@ -244,17 +244,17 @@ module Diggit
 		end
 
 		def del_analysis(name)
-			@analyses.delete_if { |a| a.name == name }
+			@analyses.delete_if { |a| a.simple_name == name }
 			Dig.it.save_config
 		end
 
 		def get_analyses(*names)
 			return analyses if names.empty?
-			analyses.select { |a| names.include?(a.name) }
+			analyses.select { |a| names.include?(a.simple_name) }
 		end
 
 		def add_join(name)
-			load_join(name) unless @joins.map(&:name).include?(name)
+			load_join(name) unless @joins.map(&:simple_name).include?(name)
 			Dig.it.save_config
 		end
 
@@ -263,13 +263,13 @@ module Diggit
 		end
 
 		def del_join(name)
-			@joins.delete_if { |j| j.name == name }
+			@joins.delete_if { |j| j.simple_name == name }
 			Dig.it.save_config
 		end
 
 		def get_joins(*names)
 			return joins if names.empty?
-			joins.select { |j| joins.include?(j.name) }
+			joins.select { |j| joins.include?(j.simple_name) }
 		end
 
 		def self.empty_config
@@ -308,7 +308,7 @@ module Diggit
 		end
 
 		def self.plugin_paths(name, type, root)
-			Dir.glob(File.join(root, 'plugins', type.to_s, '**', "#{name}.rb"))
+			Dir.glob(File.join(root, 'plugins', type.to_s, '**{,/*/**}', "#{name}.rb"))
 		end
 
 		# Constructor. Should not be called directly. Use {.instance} instead.

--- a/lib/dgit/core.rb
+++ b/lib/dgit/core.rb
@@ -21,7 +21,7 @@
 require 'oj'
 require 'rugged'
 require 'singleton'
-require_relative 'log'
+require 'dgit/log'
 
 class String
 	# Returns a underscore cased version of the string.

--- a/lib/dgit/core.rb
+++ b/lib/dgit/core.rb
@@ -122,7 +122,13 @@ module Diggit
 			if File.exist?(folder)
 				Rugged::Repository.new(folder)
 			else
-				Rugged::Repository.clone_at(url, folder)
+				progress_block = lambda do |total_objects, _, received_objects, _, _, _, _|
+    								msg = "Clone of #{url} in progress : #{received_objects}/#{total_objects} objects received.\r"
+    								$stderr.print msg
+    								@last_message_length = msg.length
+				end
+				Rugged::Repository.clone_at(url, folder, { transfer_progress: progress_block })
+				print " " * @last_message_length + "\r" # clean the line used to output transfer progress
 			end
 			self.state = :cloned
 		rescue => e

--- a/lib/dgit/plugins.rb
+++ b/lib/dgit/plugins.rb
@@ -17,7 +17,7 @@
 #
 # Copyright 2015 Jean-Rémy Falleri <jr.falleri@gmail.com>
 
-require_relative 'core'
+require 'dgit/core'
 
 module Diggit
 	# Base class for plugins. They have associated options.

--- a/lib/dgit/plugins.rb
+++ b/lib/dgit/plugins.rb
@@ -94,8 +94,9 @@ module Diggit
 		end
 
 		def self.required_addons
-			return [] if @required_addons.nil?
-			@required_addons
+			base_addons = superclass < Runnable ? superclass.required_addons : []
+			return base_addons if @required_addons.nil?
+			base_addons + @required_addons
 		end
 	end
 

--- a/lib/dgit/plugins.rb
+++ b/lib/dgit/plugins.rb
@@ -39,6 +39,10 @@ module Diggit
 		def self.name
 			to_s.underscore
 		end
+
+		def repo
+			@source.repository
+		end
 	end
 
 	class Addon < Plugin

--- a/plugins/addon/db.rb
+++ b/plugins/addon/db.rb
@@ -36,4 +36,8 @@ class Db < Diggit::Addon
 		url = @options[:mongo][:url] if @options.key?(:mongo) && @options[:mongo].key?(:url)
 		@client = Mongo::Client.new(url)
 	end
+
+	def insert(collection, data)
+		client[collection].bulk_write(data.map { |d| { insert_one: d } }, ordered: true) unless data.empty?
+	end
 end

--- a/plugins/addon/db.rb
+++ b/plugins/addon/db.rb
@@ -31,6 +31,7 @@ class Db < Diggit::Addon
 
 	def initialize(*args)
 		super
+		Mongo::Logger.logger.level = ::Logger::FATAL
 		url = DEFAULT_URL
 		url = @options[:mongo][:url] if @options.key?(:mongo) && @options[:mongo].key?(:url)
 		@client = Mongo::Client.new(url)

--- a/plugins/addon/src_opt.rb
+++ b/plugins/addon/src_opt.rb
@@ -1,0 +1,35 @@
+# encoding: utf-8
+#
+# This file is part of Diggit.
+#
+# Diggit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Diggit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Diggit.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright 2015 Jean-Rémy Falleri <jr.falleri@gmail.com>
+# Copyright 2015 Matthieu Foucault <foucaultmatthieu@gmail.com>
+
+# Manages options that are specific to a given source
+class SrcOpt < Diggit::Addon
+	SOURCES_OPTIONS_FILE = 'sources_options'
+
+	def initialize(*args)
+		super
+		sources_options_path = Diggit::Dig.it.config_path(SOURCES_OPTIONS_FILE)
+		@sources_options = {}
+		@sources_options = Oj.load_file(sources_options_path) if File.exist? sources_options_path
+	end
+
+	def [](source)
+		@sources_options[source.url]
+	end
+end

--- a/plugins/analysis/cloc.rb
+++ b/plugins/analysis/cloc.rb
@@ -27,7 +27,7 @@ class Cloc < Diggit::Analysis
 	end
 
 	def run
-		cloc = `cloc . --progress-rate=0 --quiet --yaml`
+		cloc = `cloc #{@source.folder} --progress-rate=0 --quiet --yaml`
 		return if cloc.empty?
 		yaml = YAML.load(cloc.lines[2..-1].join)
 		yaml.delete('header')

--- a/plugins/analysis/cloc.rb
+++ b/plugins/analysis/cloc.rb
@@ -16,6 +16,7 @@
 # along with Diggit.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Copyright 2015 Jean-Rémy Falleri <jr.falleri@gmail.com>
+# Copyright 2015 Matthieu Foucault <foucaultmatthieu@gmail.com>
 
 require 'yaml'
 
@@ -37,5 +38,33 @@ class Cloc < Diggit::Analysis
 
 	def clean
 		db.client['cloc'].find({ source: @source.url }).delete_one
+	end
+end
+
+class ClocPerFile < Diggit::Analysis
+	require_addons 'db'
+
+	def run
+		commit_oid = 'HEAD'
+		commit_oid = src_opt[@source]["cloc-commit-id"] if src_opt.key?(@source) && src_opt[@source].key?("cloc-commit-id")
+		@repo.checkout(commit_oid, { strategy: [:force, :remove_untracked] })
+		cloc = `cloc . --progress-rate=0 --quiet --by-file --yaml --script-lang=Python,python`
+		break if cloc.empty?
+		yaml = YAML.load(cloc.lines[2..-1].join)
+		yaml.delete('header')
+		yaml.delete('SUM')
+		cloc_a = []
+		yaml.each do |key, value|
+			# transform the hash so the filenames are not keys anymore (as they may contain a '.' it is incompatible with mongo)
+			path = key.gsub(%r{^\./}, '') # remove the './' at the start of filenames
+			cloc_a << value.merge({ path: path })
+		end
+		output = { source: @source, commit_oid: commit_oid.to_s, cloc: cloc_a }
+		col = db.client['cloc-file']
+		col.insert_one(output)
+	end
+
+	def clean
+		db.client['cloc-file'].find({ source: @source }).delete_one
 	end
 end

--- a/plugins/analysis/cloc_per_file.rb
+++ b/plugins/analysis/cloc_per_file.rb
@@ -19,12 +19,12 @@
 # Copyright 2015 Matthieu Foucault <foucaultmatthieu@gmail.com>
 
 class ClocPerFile < Diggit::Analysis
-	require_addons 'db'
+	require_addons 'db', 'src_opt'
 
 	def run
 		commit_oid = src_opt[@source]["cloc-commit-id"] unless src_opt[@source].nil?
 		commit_oid = 'HEAD' if commit_oid.nil?
-		@repo.checkout(commit_oid, { strategy: [:force, :remove_untracked] })
+		repo.checkout(commit_oid, { strategy: [:force, :remove_untracked] })
 		cloc = `cloc . --progress-rate=0 --quiet --by-file --yaml --script-lang=Python,python`
 		return if cloc.empty?
 		yaml = YAML.load(cloc.lines[2..-1].join)

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -149,4 +149,19 @@ RSpec.describe Diggit::Dig do
 		Diggit::Dig.it.analyze([], [], :clean)
 		expect(Diggit::Dig.it.journal.sources_by_ids(0)[0].all_analyses).to eq([])
 	end
+
+	it "should read source options" do
+		File.open("spec/dgit/.dgit/sources_options", "w") do |f|
+			f.write('{
+								"https://github.com/jrfaller/test-git.git":{
+									"myOption":"myValue"
+								}
+							}')
+		end
+
+		Diggit::Dig.it.config.add_analysis("test_analysis_with_sources_options")
+		expect { Diggit::Dig.it.analyze }.to output(/myValue/).to_stdout
+		Diggit::Dig.it.analyze([], [], :clean)
+		Diggit::Dig.it.config.del_analysis("test_analysis_with_sources_options")
+	end
 end

--- a/spec/dgit/plugins/analysis/test_analysis_with_sources_options.rb
+++ b/spec/dgit/plugins/analysis/test_analysis_with_sources_options.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+#
+# This file is part of Diggit.
+#
+# Diggit is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Diggit is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Diggit.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Copyright 2015 Jean-Rémy Falleri <jr.falleri@gmail.com>
+#
+
+class TestAnalysisWithSourcesOptions < Diggit::Analysis
+	require_addons "src_opt"
+
+	def initialize(*args)
+		super(args)
+	end
+
+	def run
+		p(src_opt[@source]["myOption"])
+	end
+
+	def clean
+	end
+end


### PR DESCRIPTION
Ported the sources_options (now src_opt) addon and the ClocPerFile analysis to v2.
Ported clone progress information to v2

Config now uses simple_name, which fixes failures when analyses are nested in modules
Use require instead of require_relative, so that files are not loaded twice when another gem requires dgit
Added a repo method in Analysis as a shortcut for @source.repository
Made the mongo driver less verbose
Required addons are now inherited from the parent class. If an analysis requires addons, they will be added to the ones of the parent
Added insert method in db to perform bulk write, without limitation on the number of documents
Nested the whole bin/dgit file in a module, otherwise pry is not working